### PR TITLE
i135 address duplicate fields

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -46,7 +46,7 @@ class CatalogController < ApplicationController
     config.add_facet_field 'creators-contributors_ssim', label: I18n.t(:'spotlight.search.fields.facet.creators-contributors_ssim'), limit: true
     config.add_facet_field 'place-of-origin_ssim', label: I18n.t(:'spotlight.search.fields.facet.place-of-origin_ssim'), limit: true
     config.add_facet_field 'publisher_ssim', label: I18n.t(:'spotlight.search.fields.facet.publisher_ssim'), limit: true
-    config.add_facet_field 'creation-date_ssim', label: I18n.t(:'spotlight.search.fields.facet.creation-date_ssim'), limit: true
+    config.add_facet_field 'date_ssim', label: I18n.t(:'spotlight.search.fields.facet.date_ssim'), limit: true
     config.add_facet_field 'language_ssim', label: I18n.t(:'spotlight.search.fields.facet.language_ssim'), limit: true
     config.add_facet_field 'genre_ssim', label: I18n.t(:'spotlight.search.fields.facet.genre_ssim'), limit: true
     config.add_facet_field 'culture_ssim', label: I18n.t(:'spotlight.search.fields.facet.culture_ssim'), limit: true

--- a/config/initializers/spotlight_initializer.rb
+++ b/config/initializers/spotlight_initializer.rb
@@ -314,7 +314,7 @@ Spotlight::Engine.config.upload_fields = [
   Spotlight::UploadFieldConfig.new(
     field_name: :rights_tesim,
     blacklight_options: { if: Curiosity.render_field_for_actions(show: true, index: false) },
-    label: -> { I18n.t(:spotlight.search.fields.rights_tesim) }
+    label: -> { I18n.t(:'spotlight.search.fields.rights_tesim') }
   ),
   Spotlight::UploadFieldConfig.new(
     field_name: :'record-id_tesim',

--- a/config/initializers/spotlight_initializer.rb
+++ b/config/initializers/spotlight_initializer.rb
@@ -63,17 +63,6 @@ Spotlight::Engine.config.upload_fields = [
     form_field_type: :text_area
   ),
   Spotlight::UploadFieldConfig.new(
-    field_name: :spotlight_upload_attribution_tesim,
-    blacklight_options: { if: Curiosity.render_field_for_actions(show: true, index: false) },
-    label: -> { I18n.t(:'spotlight.search.fields.spotlight_upload_attribution_tesim') }
-  ),
-  Spotlight::UploadFieldConfig.new(
-    field_name: :spotlight_upload_date_tesim,
-    # TODO? Should we display this?
-    blacklight_options: { if: false },
-    label: -> { I18n.t(:'spotlight.search.fields.spotlight_upload_date_tesim') }
-  ),
-  Spotlight::UploadFieldConfig.new(
     field_name: :'unique-id_tesim',
     # TODO? Should we display this?
     blacklight_options: { if: false },
@@ -320,16 +309,6 @@ Spotlight::Engine.config.upload_fields = [
     field_name: :'record-id_tesim',
     blacklight_options: { if: Curiosity.render_field_for_actions(show: true, index: false) },
     label: -> { I18n.t(:'spotlight.search.fields.record-id_tesim') }
-  ),
-  Spotlight::UploadFieldConfig.new(
-    field_name: :'creation-date_tesim',
-    blacklight_options: { if: false },
-    label: -> { I18n.t(:'spotlight.search.fields.creation-date_tesim') }
-  ),
-  Spotlight::UploadFieldConfig.new(
-    field_name: :'creation-date_ssim',
-    blacklight_options: { if: true },
-    label: -> { I18n.t(:'spotlight.search.fields.creation-date_ssim') }
   ),
   Spotlight::UploadFieldConfig.new(
     field_name: :'available-to_tesim',

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -98,8 +98,6 @@ en:
         note_tesim: "Note"
         additional-digital-items_tesim: "Additional Digital Items"
         record-id_tesim: "Record Id"
-        creation-date_tesim: "Creation Date"
-        creation-date_ssim: "Creation Dates"
         available-to_tesim: "Available To"
         available-to_ssim: "Available To"
         hollis-record_tesim: "Hollis Record"
@@ -140,9 +138,9 @@ en:
         manifest_url_ssm: "Manifest Url"
         facet:
           available-to_ssim: 'Available To'
-          creation-date_ssim: 'Date'
           creators-contributors_ssim: 'Creator / Contributor'
           culture_ssim: 'Culture'
+          date_ssim: 'Date'
           digital-format_ssim: 'Digital Format'
           genre_ssim: 'Genre'
           collection_ssim: 'Collection'


### PR DESCRIPTION
Ref https://github.com/harvard-lts/CURIOSity/issues/135

# What does this Pull Request do?

Remove duplicate fields as specified in the [metadata template spreadsheet](https://docs.google.com/spreadsheets/d/1ku4jp73zvvFLSJt0j80h53g3Z7SThn-3rcFOPLpesk8/edit#gid=0). Specifically, Attribution and Creation Date

# How should this be tested?

1. Login as an admin 
2. Navigate to Exhibit Dashboard > Items > Add Items 
3. Click the "Upload item" tab 

**Expected behavior:** Only one "Attribution" field should appear. "Creation Date" fields should not appear 

# Interested parties
@phil-plencner-hl @dl-maura 