### PR TITLE
Homepage CTAs and Updated FTS message wording

### DIFF
--- a/app/assets/stylesheets/spotlight-overrides/site-home.scss
+++ b/app/assets/stylesheets/spotlight-overrides/site-home.scss
@@ -862,3 +862,109 @@ table#exhibit-specific-fields {
   }
 }
 // End multi_up_item_grid.scss
+
+// Homepage blue box CTAs
+/* fancy link cards (related services & tools) */
+.hl__fancy-link {
+  background-color: #fafafa;
+  display: flex;
+    align-items: center;
+    justify-content: space-between;
+  padding: 30px;
+  position: relative;
+  text-decoration: none;
+  border-bottom: none;
+  &:before {
+    background-image: linear-gradient(-45deg, #0579b8 0%, #2a5280 100%);
+    content: "";
+    height: 100%;
+    opacity: 1;
+    position: absolute;
+      bottom: 0;
+      left: 0;
+      right: 0;
+      top: 0;
+    transition: opacity .5s ease-in;
+    width: 100%;
+  }
+  &__title {
+    color: white;
+    font-family: "Trueno", sans-serif;
+    font-size: 26px;
+    font-weight: 700;
+    line-height: 32px;
+    text-transform: none;
+    position: relative;
+    transition: color .5s ease-in;
+    z-index: 3;
+    margin-bottom: 0.4em;
+    letter-spacing: 0;
+  }
+  &__description {
+    color: white;
+    font-family: Lora,Georgia,serif;
+    font-size: 15px;
+    font-weight: normal;
+    line-height: 26px;
+    position: relative;
+    transition: color .5s ease-in;
+  }
+  &:focus, &:hover {
+    border-bottom: none;
+    .hl__fancy-link__title {
+      color: #0579b8;
+    }
+    .hl__fancy-link__description {
+      color: #1e1e1e;
+    }
+    &:before {
+      opacity: 0;
+    }
+  }
+}
+
+/* grid layouts */
+.hl__fancy-link-list__grid {
+  display: flex;
+  flex-wrap: wrap;
+  @media (min-width: 621px) {
+    margin-left: -20px;
+  }
+  @media (min-width: 1171px) {
+    margin-left: -30px;
+    margin-top: 0 !important;
+    margin-bottom: 0 !important;
+  }
+  .hl__fancy-link {
+    flex: none;
+    margin-bottom: 20px;
+    width: 100%;
+    @media (min-width: 621px) {
+      margin-left: 20px;
+      width: calc(50% - 20px);
+    }
+    @media (min-width: 1171px) {
+      margin-bottom: 30px;
+      margin-left: 30px;
+      width: calc(33.333% - 30px);
+    }
+  }
+}
+
+// have homepage collection cards spacing match with blue box ctas
+.blacklight-exhibits-index {
+  .tab-content {
+    .row {
+      margin-left: -10px;
+      margin-right: -10px;
+    }
+    .col.mb-4 {
+      padding: 0 10px;
+      margin-bottom: 20px !important;
+      @media (min-width: 1171px) {
+        padding: 0 15px;
+        margin-bottom: 30px !important;
+      }
+    }
+  }
+}

--- a/app/views/spotlight/exhibits/index.html.erb
+++ b/app/views/spotlight/exhibits/index.html.erb
@@ -1,0 +1,71 @@
+<% if (current_user && current_user.exhibits.any?) || can?(:manage, Spotlight::Exhibit) %>
+  <ul class="nav nav-tabs" role="tablist">
+    <li role="presentation" class="nav-item"><a href="#published" aria-controls="published" role="tab" data-toggle="tab" class="nav-link active"><%= t('.published') %></a></li>
+    <% if can?(:manage, Spotlight::Exhibit) && @exhibits.unpublished.accessible_by(current_ability).any? %>
+      <li role="presentation" class="nav-item"><a href="#unpublished" aria-controls="unpublished" role="tab" data-toggle="tab" class="nav-link"><%= t('.unpublished') %></a></li>
+    <% end %>
+    <% if current_user && current_user.exhibits.any? %>
+      <li role="presentation" class="nav-item"><a href="#user" aria-controls="user" role="tab" data-toggle="tab" class="nav-link"><%= t('.user') %></a></li>
+    <% end %>
+  </ul>
+<% end %>
+
+<div class="tab-content">
+  <div role="tabpanel" class="tab-pane active" id="published">
+    <% if @exhibits.published.none? %>
+      <%= render 'missing_exhibits' %>
+    <% else %>
+      <%= render 'tags', tags: @exhibits.published.all_tags %>
+      <%= render 'exhibits', exhibits: @published_exhibits %>
+
+      <% if @published_exhibits.total_count > @published_exhibits.size %>
+        <nav class="d-flex justify-content-center">
+          <ul class="pagination">
+            <li class="page-item"><%= link_to_previous_page @published_exhibits, t('views.pagination.previous').html_safe, class: 'page-link' %></li>
+            <li class="page-item"><%= link_to_next_page @published_exhibits, t('views.pagination.next').html_safe, class: 'page-link' %></li>
+          </ul>
+        </nav>
+      <% end %>
+    <% end %>
+
+  </div>
+
+  <% if @exhibits.unpublished.accessible_by(current_ability).any? %>
+    <div role="tabpanel" class="tab-pane" id="unpublished">
+      <%= render 'exhibits', exhibits: @exhibits.unpublished.ordered_by_weight.accessible_by(current_ability) %>
+    </div>
+  <% end %>
+
+  <% if current_user && current_user.exhibits.any? %>
+    <div role="tabpanel" class="tab-pane" id="user">
+      <%= render 'exhibits', exhibits: current_user.exhibits %>
+    </div>
+  <% end %>
+</div>
+
+<% content_for(:sidebar_position) { 'order-last' } %>
+<% content_for(:sidebar) do %>
+  <%= render "shared/site_sidebar" %>
+<% end %>
+
+<h2 class="hl__heading">Related Services & Tools</h2>
+<div class="hl__fancy-link-list__grid">
+  <a class="hl__fancy-link" href="#" title="Harvard Digital Collections">
+    <div class="hl__fancy-link__details">
+      <h3 class="hl__fancy-link__title">Harvard Digital Collections</h3>
+      <p class="hl__fancy-link__description">Search and discover over six million publicly available, digitized items from Harvard Library.</p>
+    </div>
+  </a>    
+  <a class="hl__fancy-link" href="#" title="Explore all Collections">
+    <div class="hl__fancy-link__details">
+      <h3 class="hl__fancy-link__title">Explore More Collections</h3>
+      <p class="hl__fancy-link__description">Browse more collections available to visit in-person and online.</p>
+    </div>
+  </a>
+  <a class="hl__fancy-link" href="#" title="Hollis for Archival Discovery">
+    <div class="hl__fancy-link__details">
+      <h3 class="hl__fancy-link__title">HOLLIS for Archival Discovery</h3>
+      <p class="hl__fancy-link__description">Catalog for exploring collection guides, finding aids and inventories to locate unique materials in Harvard's special collections and archives.</p>
+    </div>
+  </a>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -43,7 +43,7 @@ en:
         link: Show metadata results instead.
       results:
         info: Your search includes results from inside text of items.
-        link: Show metadata results only.
+        link: Search metadata instead.
       search_location: INSIDE TEXT OF ITEMS
     metadata_only:
       info: Searchable text from transcripts or OCR is available for some items.


### PR DESCRIPTION
**Homepage CTAs and Updated FTS message wording**
* * *

**JIRA Ticket**:
* https://github.com/harvard-lts/CURIOSity/issues/229
* https://github.com/harvard-lts/CURIOSity/issues/196

# What does this Pull Request do?
Front-end updates related to the two tickets mentioned above.

# How should this be tested?

Homepage
* A new section should appear below the exhibit cards with the heading "Related Services & Tools"
* There will be 3 clickable cards that take you to Harvard Digital Collections, Library.Harvard Collections, and Hollis for Archival Discovery homepages respectively.
* When hovering over a card, background turns white, while text turns blue (heading) and black (description)

Navigate to any exhibit using FTS
* After conducting a full text search, the results page gray callout box should say "Your search includes results from inside text of items. Search metadata instead." (previously said 'Show metadata results only')

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? NA
- integration tests? NA

# Interested parties
@VanessaVenti 