### PR TITLE
Moving min-width search button style out of Safari exception. (#24)

### DIFF
--- a/app/assets/stylesheets/spotlight-overrides/exhibit-home.scss
+++ b/app/assets/stylesheets/spotlight-overrides/exhibit-home.scss
@@ -165,6 +165,7 @@
       padding: 6px 12px 6px 0;
       background: $white;
       border: none;
+      min-width: 120px; 
       &::before {
         content: "";
         padding-left: 12px;
@@ -185,12 +186,6 @@
       &:hover, &:focus {
         color: $gray-600;
       }
-    }
-    /* search button override for Safari 11+ */
-    @media not all and (min-resolution:.001dpcm) { 
-        button#search { 
-        min-width: 120px; 
-        }
     }
     // full text helper box
     .fulltext-helper-text {


### PR DESCRIPTION
* Moving min-width search button style out of Safari exception.

* Removing extra line break.

**12-14-2022 arrow work*
* * *

# What does this Pull Request do?
brings over the arrow PR to Harvard

# How should this be tested?

Pull branch, run locally, see that the search box looks right on safari and other browsers

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? n
- integration tests? n

# Interested parties
Tag (@ mention) interested parties